### PR TITLE
cast Zk port as Long

### DIFF
--- a/src/main/java/backtype/storm/contrib/signals/SignalConnection.java
+++ b/src/main/java/backtype/storm/contrib/signals/SignalConnection.java
@@ -47,7 +47,7 @@ public class SignalConnection implements Watcher {
     
     @SuppressWarnings({ "rawtypes", "unchecked" })
     private static String zkHosts(Map conf) {
-        int zkPort = ((Integer) conf.get("storm.zookeeper.port"));
+        long zkPort = ((Long) conf.get("storm.zookeeper.port"));
         List<String> zkServers = (List<String>) conf.get("storm.zookeeper.servers");
 
         Iterator<String> it = zkServers.iterator();


### PR DESCRIPTION
The previous code look goods to me:
int zkPort = ((Long) conf.get("storm.zookeeper.port")).intValue();

but now:
int zkPort = ((Integer) conf.get("storm.zookeeper.port"));

and ClassCastException occurs:

ERROR (backtype.storm.contrib.signals.spout.BaseSignalSpout:35) - Error creating SignalConnection.
        java.lang.ClassCastException: java.lang.Long cannot be cast to java.lang.Integer
            at backtype.storm.contrib.signals.SignalConnection.zkHosts(SignalConnection.java:50)
            at backtype.storm.contrib.signals.SignalConnection.init(SignalConnection.java:32)
            at backtype.storm.contrib.signals.spout.BaseSignalSpout.open(BaseSignalSpout.java:33)
            at com.hmsonline.cirrus.realtime.ClientTransactionSpout.open(ClientTransactionSpout.java:84)

Is there some reason why don't use Long casting? (looks like that will be safer)
