### PR TITLE
Make it compatible with Apache Storm 1.2.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
         </developer>
     </developers>
     <properties>
-        <storm.version>1.0.3</storm.version>
+        <storm.version>1.2.3</storm.version>
     </properties>
     <dependencies>
         <dependency>
@@ -51,8 +51,8 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
It wasn't compatible with Storm 1.2.3 due to newer Curator version used in 1.2.3. After bumping it up it works fine.

Also bumped up Java to 1.8.